### PR TITLE
Correctly identifying \r as whitespace.

### DIFF
--- a/libraries/TinyXML/TinyXML.cpp
+++ b/libraries/TinyXML/TinyXML.cpp
@@ -56,7 +56,7 @@ void TinyXML::processChar(uint8_t ch)
     switch ( chToParse )
     {
     case whiteSpace:
-      if (ch == ' ' || ch == '\t' || ch == '\n' | ch == '\r') bMatch=true;
+      if (ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r') bMatch=true;
       break;
     case alpha:
       if (isAlpha(ch))  bMatch=true;


### PR DESCRIPTION
Using | (bitwise OR) instead of || (logical OR) would fail to
detect \r as whitespace.

This is a whitespace fix to `TinyXML::processChar()`. The | (bitwise OR)
operator has a higher precedence the || (logical OR). The result is that
`<any character> | '\r'` is always true, and the order precedence bound
true with the prior `ch == '\n'` effectively making it `ch == '\n' | true`,
so `ch | '\r'` was a no-op. What this change does mean is that previously
\r was not whitespace, but now it is.